### PR TITLE
Fill required summary property in the podspec

### DIFF
--- a/RNSiriShortcuts.podspec
+++ b/RNSiriShortcuts.podspec
@@ -4,11 +4,11 @@ package = JSON.parse(File.read(File.join(__dir__, "package.json")))
 
 Pod::Spec.new do |s|
   s.name         = "RNSiriShortcuts"
-  s.version      = package["version"]
-  s.summary      = package["description"]
+  s.summary      = "React Native Siri Shortcut"
   s.description  = <<-DESC
                   RNSiriShortcuts
                    DESC
+  s.version      = package["version"]
   s.homepage     = "https://github.com/author/RNSiriShortcuts"
   s.license      = "MIT"
   # s.license    = { :type => "MIT", :file => "FILE_LICENSE" }
@@ -22,4 +22,3 @@ Pod::Spec.new do |s|
   s.dependency "React"
   #s.dependency "others"
 end
-


### PR DESCRIPTION
Hey! Thanks for this awesome library!

In this PR i'm just filling the summary property to avoid the following error:

<img width="644" alt="screen shot 2018-09-26 at 23 50 55" src="https://user-images.githubusercontent.com/228720/46120875-a97dcc00-c1e7-11e8-9b94-67a807e7fdcd.png">
