### PR TITLE
prevent native iOS12 only code being called for AddToSiriButton

### DIFF
--- a/AddToSiriButton.js
+++ b/AddToSiriButton.js
@@ -3,8 +3,23 @@ import type { ShortcutOptions } from ".";
 
 import * as React from "react";
 import { requireNativeComponent, View, StyleSheet } from "react-native";
+import { Platform } from 'react-native';
 
-const RNTAddToSiriButton = requireNativeComponent("RNTAddToSiriButton");
+const masterVersion = parseInt(Platform.Version, 10);
+
+var RNTAddToSiriButton
+if (masterVersion >= 12) {
+  RNTAddToSiriButton = requireNativeComponent("RNTAddToSiriButton");
+} else {
+  RNTAddToSiriButton = () => {
+    throw new Error("AddToSiriButton not available on iOS < 12")
+    return null
+  }
+}
+
+export const AddSiriButtonAvailable = () => {
+  return masterVersion >= 12;
+}
 
 export const SiriButtonStyles = {
   white: 0,

--- a/README.md
+++ b/README.md
@@ -295,12 +295,29 @@ try {
 <AddToSiriButton
   style={style: ViewStyleProps}
   buttonStyle={SiriButtonStyles.white: 0 | 1 | 2 | 3} // Recommended you use the exported SiriButtonStyles object
-  onPress={() => { 
-    console.log('I was pressed!') 
+  onPress={() => {
+    console.log('I was pressed!')
   }: () => void}
   shortcut={options: ShortcutOptions}
 />
 ```
+Preventing use on iOS < 12
+
+```javascript
+import AddToSiriButton, { AddSiriButtonAvailable } from "react-native-siri-shortcut/AddToSiriButton";
+
+render() {
+  ...
+  {AddSiriButtonAvailable() ? <AddToSiriButton ... />
+               : <Text onPress={() => {
+                 Alert.alert(
+                   "Sorry, only available for iOS 12 and later...");
+                 }}>Add to Siri</Text>
+  }
+}
+
+```
+
 
 #### Black Theme
 ![Black Theme](https://developer.apple.com/design/human-interface-guidelines/sirikit/images/AddToSiri-Black.png)


### PR DESCRIPTION
For https://github.com/Gustash/react-native-siri-shortcut/issues/12

One approach here:

1. AddSiriButtonAvailable check is available to caller to allow different behavior/rendering
2. javascript exception if app actually does try to render the component on iOS < 12.
