### PR TITLE
feat(shortcuts): provide access to voice shortcuts

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,8 @@ export type ShortcutOptions = {
 };
 
 export type PresentShortcutCallbackData = {
-  status: "cancelled" | "added" | "deleted" | "updated"
+  status: "cancelled" | "added" | "deleted" | "updated",
+  shortcut: string
 };
 
 const noop = () => ({});
@@ -78,4 +79,8 @@ export const clearShortcutsWithIdentifiers = safeCall(
 export const presentShortcut = safeCall(
   (opts: ShortcutOptions, callback: () => PresentShortcutCallbackData) =>
     RNSiriShortcuts.presentShortcut(opts, callback)
+);
+
+export const getShortcuts = safeCall(() =>
+  RNSiriShortcuts.getShortcuts()
 );

--- a/ios/RNSiriShortcuts.m
+++ b/ios/RNSiriShortcuts.m
@@ -17,5 +17,6 @@ RCT_EXTERN_METHOD(clearShortcutsWithIdentifiers: (NSArray *)persistentIdentifier
 RCT_EXTERN_METHOD(donateShortcut: (NSDictionary *) options)
 RCT_EXTERN_METHOD(suggestShortcuts: (NSArray<NSDictionary *> *) options)
 RCT_EXTERN_METHOD(presentShortcut: (NSDictionary *) options callback: (RCTResponseSenderBlock) callback)
+RCT_EXTERN_METHOD(getShortcuts:(RCTPromiseResolveBlock)resolve rejecter: (RCTPromiseRejectBlock)reject)
 
 @end

--- a/ios/RNSiriShortcuts.swift
+++ b/ios/RNSiriShortcuts.swift
@@ -173,6 +173,14 @@ class ShortcutsModule: RCTEventEmitter, INUIAddVoiceShortcutViewControllerDelega
     }
     
     @available(iOS 12.0, *)
+    @objc func getShortcuts(_ resolve: @escaping RCTPromiseResolveBlock,
+                            rejecter reject: RCTPromiseRejectBlock) -> Void {
+        resolve((voiceShortcuts as! Array<INVoiceShortcut>).map({ (shortcut) -> String in
+            return shortcut.invocationPhrase
+        }))
+    }
+    
+    @available(iOS 12.0, *)
     @objc func presentShortcut(_ jsonOptions: Dictionary<String, Any>, callback: @escaping RCTResponseSenderBlock) {
         presentShortcutCallback = callback
         let activity = ShortcutsModule.generateUserActivity(jsonOptions)
@@ -201,12 +209,13 @@ class ShortcutsModule: RCTEventEmitter, INUIAddVoiceShortcutViewControllerDelega
         rootViewController.present(presenterViewController!, animated: true, completion: nil)
     }
     
-    func dismissPresenter(_ status: VoiceShortcutMutationStatus) {
+    @available(iOS 12.0, *)
+    func dismissPresenter(_ status: VoiceShortcutMutationStatus, withShortcut voiceShortcut: INVoiceShortcut?) {
         presenterViewController?.dismiss(animated: true, completion: nil)
         presenterViewController = nil
         presentShortcutCallback?([
-            ["status": status.rawValue]
-            ])
+            ["status": status.rawValue, "shortcut": voiceShortcut?.invocationPhrase]
+        ])
         presentShortcutCallback = nil
     }
     
@@ -216,13 +225,13 @@ class ShortcutsModule: RCTEventEmitter, INUIAddVoiceShortcutViewControllerDelega
         if (voiceShortcut != nil) {
             voiceShortcuts.append(voiceShortcut!)
         }
-        dismissPresenter(.added)
+        dismissPresenter(.added, withShortcut: voiceShortcut)
     }
     
     @available(iOS 12.0, *)
     func addVoiceShortcutViewControllerDidCancel(_ controller: INUIAddVoiceShortcutViewController) {
         // Adding shortcut cancelled
-        dismissPresenter(.cancelled)
+        dismissPresenter(.cancelled, withShortcut: nil)
     }
     
     @available(iOS 12.0, *)
@@ -240,7 +249,7 @@ class ShortcutsModule: RCTEventEmitter, INUIAddVoiceShortcutViewControllerDelega
             }
         }
         
-        dismissPresenter(.updated)
+        dismissPresenter(.updated, withShortcut: voiceShortcut)
     }
     
     @available(iOS 12.0, *)
@@ -256,13 +265,13 @@ class ShortcutsModule: RCTEventEmitter, INUIAddVoiceShortcutViewControllerDelega
             voiceShortcuts.remove(at: indexOfDeletedShortcut!)
         }
         
-        dismissPresenter(.deleted)
+        dismissPresenter(.deleted, withShortcut: nil)
     }
     
     @available(iOS 12.0, *)
     func editVoiceShortcutViewControllerDidCancel(_ controller: INUIEditVoiceShortcutViewController) {
         // Shortcut edit was cancelled
-        dismissPresenter(.cancelled)
+        dismissPresenter(.cancelled, withShortcut: nil)
     }
     
     // become current


### PR DESCRIPTION
This provides a method to get all shortcuts and passes through the shortcut being added or edited. I needed this feature for my app, so I just added it to this lib. Perhaps you'll agree it would be a useful addition.

Example usage:

```js
import { getShortcuts } from 'react-native-siri-shortcut'

...
async componentDidMount() {
  const shortcuts = await getShortcuts()
}
```

also

```js
import { presentShorcut } from 'react-native-siri-shortcut'

...
onPress={() =>
  presentShortcut(opts, ({ status, shortcut = '' }) => {
    switch (status) {
      case 'added':
        console.log(`Added ${shortcut}`)
        break
      case 'updated':
        console.log(`Updated ${shortcut}`)
        break
      ...
    }
  })
}
```