### PR TITLE
fix(ios): fix autolinking and import definition when installing with cocoapods

### DIFF
--- a/RNSiriShortcuts.podspec
+++ b/RNSiriShortcuts.podspec
@@ -3,7 +3,7 @@ require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
 Pod::Spec.new do |s|
-  s.name         = "react-native-siri-shortcut"
+  s.name         = "RNSiriShortcuts"
   s.version      = package['version']
   s.summary      = package['description']
   s.license      = package['license']

--- a/ios/RNSiriShortcuts.swift
+++ b/ios/RNSiriShortcuts.swift
@@ -20,15 +20,15 @@ enum VoiceShortcutMutationStatus: String {
 }
 
 @objc(ShortcutsModule)
-class ShortcutsModule: RCTEventEmitter, INUIAddVoiceShortcutViewControllerDelegate, INUIEditVoiceShortcutViewControllerDelegate {
+open class ShortcutsModule: RCTEventEmitter, INUIAddVoiceShortcutViewControllerDelegate, INUIEditVoiceShortcutViewControllerDelegate {
     var hasListeners: Bool = false
     
     var presenterViewController: UIViewController?
     var voiceShortcuts: Array<NSObject> = [] // Actually it's INVoiceShortcut, but that way we would have to break compatibility with simple NSUserActivity behaviour
     var presentShortcutCallback: RCTResponseSenderBlock?
-    @objc static var initialUserActivity: NSUserActivity?
+    @objc public static var initialUserActivity: NSUserActivity?
     
-    @objc static func onShortcutReceived(userActivity: NSUserActivity) {
+    @objc public static func onShortcutReceived(userActivity: NSUserActivity) {
         let userInfo = userActivity.userInfo
         let activityType = userActivity.activityType
         
@@ -63,7 +63,7 @@ class ShortcutsModule: RCTEventEmitter, INUIAddVoiceShortcutViewControllerDelega
         )
     }
     
-    override func startObserving() {
+    override open func startObserving() {
         hasListeners = true
         
         if let userActivity = ShortcutsModule.initialUserActivity {
@@ -72,15 +72,15 @@ class ShortcutsModule: RCTEventEmitter, INUIAddVoiceShortcutViewControllerDelega
         }
     }
     
-    override func stopObserving() {
+    override open func stopObserving() {
         hasListeners = false
     }
     
-    override static func requiresMainQueueSetup() -> Bool {
+    override static public func requiresMainQueueSetup() -> Bool {
         return true
     }
     
-    override func supportedEvents() -> [String]! {
+    override open func supportedEvents() -> [String]! {
         return ["SiriShortcutListener"]
     }
     
@@ -247,7 +247,7 @@ class ShortcutsModule: RCTEventEmitter, INUIAddVoiceShortcutViewControllerDelega
     }
     
     @available(iOS 12.0, *)
-    func addVoiceShortcutViewController(_ controller: INUIAddVoiceShortcutViewController, didFinishWith voiceShortcut: INVoiceShortcut?, error: Error?) {
+    public func addVoiceShortcutViewController(_ controller: INUIAddVoiceShortcutViewController, didFinishWith voiceShortcut: INVoiceShortcut?, error: Error?) {
         // Shortcut was added
         if (voiceShortcut != nil) {
             voiceShortcuts.append(voiceShortcut!)
@@ -256,13 +256,13 @@ class ShortcutsModule: RCTEventEmitter, INUIAddVoiceShortcutViewControllerDelega
     }
     
     @available(iOS 12.0, *)
-    func addVoiceShortcutViewControllerDidCancel(_ controller: INUIAddVoiceShortcutViewController) {
+    public func addVoiceShortcutViewControllerDidCancel(_ controller: INUIAddVoiceShortcutViewController) {
         // Adding shortcut cancelled
         dismissPresenter(.cancelled, withShortcut: nil)
     }
     
     @available(iOS 12.0, *)
-    func editVoiceShortcutViewController(_ controller: INUIEditVoiceShortcutViewController, didUpdate voiceShortcut: INVoiceShortcut?, error: Error?) {
+    public func editVoiceShortcutViewController(_ controller: INUIEditVoiceShortcutViewController, didUpdate voiceShortcut: INVoiceShortcut?, error: Error?) {
         // Shortcut was updated
         
         if (voiceShortcut != nil) {
@@ -280,7 +280,7 @@ class ShortcutsModule: RCTEventEmitter, INUIAddVoiceShortcutViewControllerDelega
     }
     
     @available(iOS 12.0, *)
-    func editVoiceShortcutViewController(_ controller: INUIEditVoiceShortcutViewController, didDeleteVoiceShortcutWithIdentifier deletedVoiceShortcutIdentifier: UUID) {
+    public func editVoiceShortcutViewController(_ controller: INUIEditVoiceShortcutViewController, didDeleteVoiceShortcutWithIdentifier deletedVoiceShortcutIdentifier: UUID) {
         // Shortcut was deleted
         
         // Keep a reference so we can notify JS about what the invocationPhrase was for this shortcut
@@ -300,7 +300,7 @@ class ShortcutsModule: RCTEventEmitter, INUIAddVoiceShortcutViewControllerDelega
     }
     
     @available(iOS 12.0, *)
-    func editVoiceShortcutViewControllerDidCancel(_ controller: INUIEditVoiceShortcutViewController) {
+    public func editVoiceShortcutViewControllerDidCancel(_ controller: INUIEditVoiceShortcutViewController) {
         // Shortcut edit was cancelled
         dismissPresenter(.cancelled, withShortcut: nil)
     }

--- a/ios/RNTAddToSiriButtonManager.swift
+++ b/ios/RNTAddToSiriButtonManager.swift
@@ -10,12 +10,12 @@ import Foundation
 
 @available(iOS 12.0, *)
 @objc (RNTAddToSiriButtonManager)
-class RNTAddToSiriButtonManager : RCTViewManager {
-    @objc override func view() -> UIView! {
+open class RNTAddToSiriButtonManager : RCTViewManager {
+    @objc override open func view() -> UIView! {
         return SiriButtonView(frame: UIScreen().bounds)
     }
     
-    override static func requiresMainQueueSetup() -> Bool {
+    override static public func requiresMainQueueSetup() -> Bool {
         return true
     }
 }


### PR DESCRIPTION
This PR fixes 2 issues when installing this plugin in RN >=0.61 and autolinking.

1. `#import <RNSiriShortcuts/RNSiriShortcuts-Swift.h>` was broken because the podspec filename was  `react-native-siri-shortcut.podspec` and `name` was set to `react-native-siri-shortcut`, which resulted in the need to do `#import <react_native_siri_shortcut/react_native_siri_shortcut-Swift.h>`. With this PR, the documentation need not be changed (although you'll be able to note that `react-native link` should be avoided in RN >= 0.61).
2. autolinking now works! Users should include `use_frameworks!` in their Podfiles (required for pods that use Swift). Adding `open` or `public` to classes, functions, and properties was necessary in order to expose them in a framework setting.

## Important note

`use_frameworks!` is broken in RN 0.60.x, but is fixed on the react-native master branch and will be released in 0.61.0. I've confirmed this PR works with `0.61.0-rc.3`. This means that there's no easy way to install this plugin if using RN 0.60.x. There's nothing that can be done on the plugin's end. It requires manual linking and some convoluted maneuvering to avoid being built as a pod so the plugin is built the old way within the user's project. That said, it's all moot as soon as the user upgrades to RN 0.61.

Fixes gh-25