### PR TITLE
Add swift version requirement to podspec

### DIFF
--- a/RNSiriShortcuts.podspec
+++ b/RNSiriShortcuts.podspec
@@ -11,6 +11,7 @@ Pod::Spec.new do |s|
   s.authors      = package['author']
   s.homepage     = package['homepage']
   s.platform     = :ios, "9.0"
+  s.swift_version = "4.1"
 
   s.source       = { :git => "https://github.com/Gustash/react-native-siri-shortcut.git", :tag => "v#{s.version}" }
   s.source_files  = "ios/**/*.{h,m,swift}"


### PR DESCRIPTION
Fixes https://github.com/Gustash/react-native-siri-shortcut/issues/27 and similar error messages when running `pod install`.