### PR TITLE
Add TypeScript module definitions

### DIFF
--- a/AddToSiriButton.d.ts
+++ b/AddToSiriButton.d.ts
@@ -1,0 +1,21 @@
+import * as React from "react";
+import { ViewStyle } from "react-native";
+import { ShortcutOptions } from "./";
+
+export const SiriButtonStyles: {
+  white: 0;
+  whiteOutline: 1;
+  black: 2;
+  blackOutline: 3;
+};
+
+type Props = {
+  buttonStyle?: 0 | 1 | 2 | 3;
+  style?: ViewStyle;
+  shortcut: ShortcutOptions;
+  onPress?: () => void;
+};
+
+declare const AddtoSiriButton: React.ComponentType<Props>;
+
+export default AddtoSiriButton;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,50 @@
+import { NativeEventEmitter } from "react-native";
+
+export type ShortcutOptions = {
+  activityType: string;
+  title?: string;
+  requiredUserInfoKeys?: Array<string>;
+  userInfo?: any;
+  needsSave?: boolean;
+  keywords?: Array<string>;
+  persistentIdentifier?: string;
+  isEligibleForHandoff?: boolean;
+  isEligibleForSearch?: boolean;
+  isEligibleForPublicIndexing?: boolean;
+  expirationDate?: number;
+  webpageURL?: string;
+  isEligibleForPrediction?: boolean;
+  suggestedInvocationPhrase?: string;
+};
+
+export type PresentShortcutCallbackData = {
+  status: "cancelled" | "added" | "deleted" | "updated";
+  phrase: string | undefined;
+};
+
+export type ShortcutData = {
+  identifier: string;
+  phrase: string;
+  options?: ShortcutOptions;
+};
+
+export const SiriShortcutsEvent: NativeEventEmitter;
+
+export function donateShortcut(options: ShortcutOptions): void;
+
+export function suggestShortcuts(options: Array<ShortcutOptions>): void;
+
+export function presentShortcut(
+  options: ShortcutOptions,
+  callback: () => PresentShortcutCallbackData
+): void;
+
+export function getShortcuts(): Promise<Array<ShortcutData>>;
+
+export function clearAllShortcuts(): Promise<void>;
+
+export function clearShortcutsWithIdentifiers(
+  identifierArray: Array<string>
+): Promise<void>;
+
+export const supportsPresentShortcut: boolean;


### PR DESCRIPTION
Thanks for building this library!

This PR adds TypeScript module definitions for the exported API. These are based originally on the internal flow types, with a few TS specific changes.

I didn't type `createShortcut` since it's deprecated anyway, but I think everything else is covered.

Make sure these files are in the built npm package to get the types to work for everyone 🚀 