### PR TITLE
docs(types): fix presentShortcut's callback definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -36,7 +36,7 @@ export function suggestShortcuts(options: Array<ShortcutOptions>): void;
 
 export function presentShortcut(
   options: ShortcutOptions,
-  callback: () => PresentShortcutCallbackData
+  callback: (data: PresentShortcutCallbackData) => void
 ): void;
 
 export function getShortcuts(): Promise<Array<ShortcutData>>;


### PR DESCRIPTION
- PresentShortcutCallbackData is passed as an argument,
  and is not actually expected to be returned from the callback