### PR TITLE
fix: potential UI thread block on initialization

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -316,7 +316,7 @@ PODS:
     - React-cxxreact (= 0.64.1)
     - React-jsi (= 0.64.1)
     - React-perflogger (= 0.64.1)
-  - RNSiriShortcuts (2.0.0):
+  - RNSiriShortcuts (2.0.1):
     - React
   - Yoga (1.14.0)
   - YogaKit (1.18.1):
@@ -454,7 +454,7 @@ SPEC CHECKSUMS:
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
   FBLazyVector: 7b423f9e248eae65987838148c36eec1dbfe0b53
-  FBReactNativeSpec: 748980c58bf4ccad12f8a4a48068d513723238d7
+  FBReactNativeSpec: 00518b78c0370a2ac833a217f10857ff2087a1a0
   Flipper: d3da1aa199aad94455ae725e9f3aa43f3ec17021
   Flipper-DoubleConversion: 38631e41ef4f9b12861c67d17cb5518d06badc41
   Flipper-Folly: 755929a4f851b2fb2c347d533a23f191b008554c
@@ -488,10 +488,10 @@ SPEC CHECKSUMS:
   React-RCTVibration: 4b99a7f5c6c0abbc5256410cc5425fb8531986e1
   React-runtimeexecutor: ff951a0c241bfaefc4940a3f1f1a229e7cb32fa6
   ReactCommon: bedc99ed4dae329c4fcf128d0c31b9115e5365ca
-  RNSiriShortcuts: d1ddd8b4648ebd21e3f12b8450083a2954a9a1d9
+  RNSiriShortcuts: 1fb92383938ca78890aa6bc1ca1a94a2dd6762aa
   Yoga: a7de31c64fe738607e7a3803e3f591a4b1df7393
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
 PODFILE CHECKSUM: 024ee5ef5619e9d8df2e4f0297223efd45b08a17
 
-COCOAPODS: 1.10.1
+COCOAPODS: 1.11.2

--- a/example/ios/example.xcodeproj/project.pbxproj
+++ b/example/ios/example.xcodeproj/project.pbxproj
@@ -425,7 +425,7 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-example-exampleTests/Pods-example-exampleTests-frameworks.sh",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/OpenSSL/OpenSSL.framework/OpenSSL",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/OpenSSL-Universal/OpenSSL.framework/OpenSSL",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
@@ -443,7 +443,7 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-example/Pods-example-frameworks.sh",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/OpenSSL/OpenSSL.framework/OpenSSL",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/OpenSSL-Universal/OpenSSL.framework/OpenSSL",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (

--- a/ios/RNSiriShortcuts.swift
+++ b/ios/RNSiriShortcuts.swift
@@ -23,7 +23,16 @@ enum VoiceShortcutMutationStatus: String {
 open class ShortcutsModule: RCTEventEmitter, INUIAddVoiceShortcutViewControllerDelegate, INUIEditVoiceShortcutViewControllerDelegate {
     var hasListeners: Bool = false
     
-    var editingVoiceShortcut: NSObject? // Keep support for iOS <9
+    var _editingVoiceShortcut: NSObject? // Keep support for iOS <9
+    @available(iOS 12.0, *)
+    var editingVoiceShortcut: INVoiceShortcut? {
+        get {
+            _editingVoiceShortcut as? INVoiceShortcut
+        }
+        set {
+           _editingVoiceShortcut = newValue
+        }
+    }
     var presenterViewController: UIViewController?
     var presentShortcutCallback: RCTResponseSenderBlock?
     @objc public static var initialUserActivity: NSUserActivity?
@@ -297,7 +306,7 @@ open class ShortcutsModule: RCTEventEmitter, INUIAddVoiceShortcutViewControllerD
     public func editVoiceShortcutViewController(_ controller: INUIEditVoiceShortcutViewController,
                                                 didDeleteVoiceShortcutWithIdentifier deletedVoiceShortcutIdentifier: UUID) {
         // Shortcut was deleted
-        guard let editingVoiceShortcut = self.editingVoiceShortcut as? INVoiceShortcut else {
+        guard let editingVoiceShortcut = self.editingVoiceShortcut else {
             print("Could not find shortcut being edited.")
             dismissPresenter(.deleted, withShortcut: nil)
             return

--- a/ios/RNSiriShortcuts.swift
+++ b/ios/RNSiriShortcuts.swift
@@ -249,16 +249,15 @@ open class ShortcutsModule: RCTEventEmitter, INUIAddVoiceShortcutViewControllerD
                     // The shortcut was already added, so we present a form to edit it
                     self.editingVoiceShortcut = addedVoiceShortcut
                     let presenterViewController = INUIEditVoiceShortcutViewController(voiceShortcut: addedVoiceShortcut)
-                    presenterViewController.modalPresentationStyle = .formSheet
                     presenterViewController.delegate = self
                     self.presenterViewController = presenterViewController
                 } else {
                     // The shortcut was not added yet, so present a form to add it
                     let presenterViewController = INUIAddVoiceShortcutViewController(shortcut: shortcut)
-                    presenterViewController.modalPresentationStyle = .formSheet
                     presenterViewController.delegate = self
                     self.presenterViewController = presenterViewController
                 }
+                self.presenterViewController!.modalPresentationStyle = .formSheet
 
                 UIApplication.shared.keyWindow!.rootViewController!.present(self.presenterViewController!, animated: true, completion: nil)
             }

--- a/ios/RNSiriShortcuts.swift
+++ b/ios/RNSiriShortcuts.swift
@@ -338,7 +338,6 @@ open class ShortcutsModule: RCTEventEmitter, INUIAddVoiceShortcutViewControllerD
 
             completion(nil, nil)
         }
-        return
     }
     
     // become current


### PR DESCRIPTION
The module was keeping track of the recorded shortcuts in an internal array. This array would be updated whenever:

- The module initialized;
- The app came back to the foreground;
- A shortcut was added/updated/deleted by the user.

Even though the underlying method for fetching these shortcuts is asynchronous, there were reports of slow app initialization, so it seems like initialization was blocking.

This PR changes this behavior in the following ways:

- No longer keeping track of recorded shortcuts internally;
- Recorded shortcuts are requested whenever needed (`getShortcuts` or `presentShortcut` are called);
- Only keeping track of the shortcut being edited, if any, when calling `presentShortcut`. This is so we can identify which shortcut phrase was used in the deleted shortcut, avoiding a feature regression.

Fixes #59 