### PR TITLE
chore: support React 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "licenseFilename": "LICENSE",
   "readmeFilename": "README.md",
   "peerDependencies": {
-    "react": ">=16.8.1 <18",
+    "react": ">=16.8.1 <19",
     "react-native": ">=0.60.0-rc.0 <1.0.x"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes #98 

The most recent React Native versions depend on React 18 instead of 17. This enables the peer dependency to resolve properly on recent versions.