### PR TITLE
INUIAddVoiceShortcutButton iOS 16.4 fix

### DIFF
--- a/ios/RNSSAddToSiriButtonViewManager.m
+++ b/ios/RNSSAddToSiriButtonViewManager.m
@@ -42,7 +42,7 @@ RCT_CUSTOM_VIEW_PROPERTY(buttonStyle, INUIAddVoiceShortcutButtonStyle, RNSSAddTo
 
 - (NSDictionary *)constantsToExport
 {
-    INUIAddVoiceShortcutButton *button = [INUIAddVoiceShortcutButton new];
+    INUIAddVoiceShortcutButton *button = [INUIAddVoiceShortcutButton alloc];
     button.translatesAutoresizingMaskIntoConstraints = NO;
     [button layoutIfNeeded];
     


### PR DESCRIPTION
Fixes a build error when compiling on Xcode 14.3 (or later) with iOS 16.4 SDK