### PR TITLE
fix: `new` not being available for INUIAddVoiceShortcutButton

### DIFF
--- a/ios/RNSSAddToSiriButtonViewManager.m
+++ b/ios/RNSSAddToSiriButtonViewManager.m
@@ -42,7 +42,7 @@ RCT_CUSTOM_VIEW_PROPERTY(buttonStyle, INUIAddVoiceShortcutButtonStyle, RNSSAddTo
 
 - (NSDictionary *)constantsToExport
 {
-    INUIAddVoiceShortcutButton *button = [INUIAddVoiceShortcutButton new];
+    INUIAddVoiceShortcutButton *button = [[INUIAddVoiceShortcutButton alloc] initWithStyle:INUIAddVoiceShortcutButtonStyleBlack];
     button.translatesAutoresizingMaskIntoConstraints = NO;
     [button layoutIfNeeded];
     


### PR DESCRIPTION
Fixes #131 